### PR TITLE
Make shutdown faster in case of a long running event handler

### DIFF
--- a/rdc_fs_watcher.cpp
+++ b/rdc_fs_watcher.cpp
@@ -36,7 +36,7 @@
 #include <type_traits>
 #include <iostream>
 
- // Information about a subscription for the changes of a single directory.
+// Information about a subscription for the changes of a single directory.
 class WatchInfo final
 {
 private:
@@ -202,9 +202,9 @@ void RdcFSWatcher::processEvent(DWORD numberOfBytesTrs, OVERLAPPED* overlapped)
 
 	WatchInfo& watchInfo = watchInfoIt->second;
 
-	// If we're already in PendingClose state, and receive a legitimate notification, then
-	// we don't emit a change notification, however, we delete the WatchInfo, just like when
-	// we receive a "closing" notification.
+	// If we're already in PendingClose state, and receive a legitimate notification,
+	// then we don't emit a change notification -- we delete the WatchInfo, just like
+	// when a "closing" notification is received.
 
 	if (watchInfo.canRun()) {
 		auto notificationResult = watchInfo.processNotifications();

--- a/rdc_fs_watcher.h
+++ b/rdc_fs_watcher.h
@@ -83,6 +83,8 @@ private:
 	HandlePtr iocp;
 	// has the "event loop" stopped?
 	std::atomic<bool> stopped;
+	// are we about the shutdown?
+	std::atomic<bool> shuttingDown;
 	// runs the "event loop", that checks the IOCP
 	std::thread loop;
 


### PR DESCRIPTION
As detailed in issue #1 if `changeEvent()` takes a long time and new filesystem events keep happening, then the shutdown of the application is delayed.

This PR solves that problem by not processing entirely these events during shutdown.